### PR TITLE
Fix BSM theta: decay term was 4x too large and dropped the discount factor

### DIFF
--- a/vanilla_option_pricers/black_scholes.py
+++ b/vanilla_option_pricers/black_scholes.py
@@ -348,9 +348,9 @@ def compute_bsm_vanilla_theta(ttm: float,
         d1 = np.log(forward / strike) / s_t + 0.5 * s_t
         d2 = d1 - s_t
         if optiontype == 'C' or optiontype == 'IC':
-            theta = -forward * npdf(d1)*vol/(0.5*np.sqrt(ttm)) - discount_rate*discfactor*strike*ncdf(d2)
+            theta = -discfactor * forward * npdf(d1)*vol/(2.0*np.sqrt(ttm)) - discount_rate*discfactor*strike*ncdf(d2)
         elif optiontype == 'P' or optiontype == 'IP':
-            theta = -forward * npdf(d1)*vol/(0.5*np.sqrt(ttm)) + discount_rate*discfactor*strike*ncdf(-d2)
+            theta = -discfactor * forward * npdf(d1)*vol/(2.0*np.sqrt(ttm)) + discount_rate*discfactor*strike*ncdf(-d2)
         else:
             raise NotImplementedError(f"optiontype")
     return theta

--- a/vanilla_option_pricers/tests/test_black_scholes.py
+++ b/vanilla_option_pricers/tests/test_black_scholes.py
@@ -1,0 +1,89 @@
+"""
+Numerical checks for the Black-Scholes-Merton pricer and its greeks.
+
+Each greek is compared against a finite difference of the pricer itself, so the
+pricer is the reference. Theta is taken with the spot held fixed (the forward and
+the discount factor both move with time to maturity), matching the discounting the
+analytic theta assumes.
+"""
+import math
+
+import numpy as np
+
+from vanilla_option_pricers.black_scholes import (
+    compute_bsm_vanilla_delta,
+    compute_bsm_vanilla_gamma,
+    compute_bsm_vanilla_price,
+    compute_bsm_vanilla_theta,
+    compute_bsm_vanilla_vega,
+)
+
+# (spot, strike, ttm, vol, rate)
+CASES = [
+    (100.0, 100.0, 1.00, 0.20, 0.00),
+    (100.0, 100.0, 1.00, 0.20, 0.05),
+    (90.0, 100.0, 2.00, 0.30, 0.10),
+    (110.0, 95.0, 0.50, 0.25, 0.03),
+    (100.0, 120.0, 0.25, 0.40, 0.07),
+    (50.0, 65.0, 0.43, 0.31, 0.02),
+]
+
+
+def _price(spot, strike, ttm, vol, optiontype, rate):
+    return compute_bsm_vanilla_price(spot * np.exp(rate * ttm), strike, ttm, vol,
+                                     optiontype, np.exp(-rate * ttm))
+
+
+def test_price_put_call_parity():
+    for spot, strike, ttm, vol, rate in CASES:
+        call = _price(spot, strike, ttm, vol, 'C', rate)
+        put = _price(spot, strike, ttm, vol, 'P', rate)
+        forward, discfactor = spot * np.exp(rate * ttm), np.exp(-rate * ttm)
+        assert abs((call - put) - discfactor * (forward - strike)) < 1e-10
+
+
+def test_theta_reference_value():
+    # ATM, zero rate: closed-form Black decay -F n(d1) vol / (2 sqrt(T)), computed here
+    # independently of the library.
+    forward, strike, ttm, vol = 100.0, 100.0, 1.0, 0.20
+    d1 = 0.5 * vol * math.sqrt(ttm)
+    n_d1 = math.exp(-0.5 * d1 * d1) / math.sqrt(2.0 * math.pi)
+    expected = -forward * n_d1 * vol / (2.0 * math.sqrt(ttm))
+    theta = compute_bsm_vanilla_theta(ttm, forward, strike, vol, 'C', 1.0, 0.0)
+    assert abs(theta - expected) < 1e-6
+
+
+def test_theta_matches_finite_difference():
+    h = 1e-6
+    for spot, strike, ttm, vol, rate in CASES:
+        for optiontype in ('C', 'P'):
+            forward, discfactor = spot * np.exp(rate * ttm), np.exp(-rate * ttm)
+            analytic = compute_bsm_vanilla_theta(ttm, forward, strike, vol, optiontype,
+                                                 discfactor, rate)
+            fd = -(_price(spot, strike, ttm + h, vol, optiontype, rate)
+                   - _price(spot, strike, ttm - h, vol, optiontype, rate)) / (2.0 * h)
+            assert abs(analytic - fd) < 1e-4
+
+
+def test_delta_vega_gamma_match_finite_difference():
+    # forward-measure greeks (discfactor = 1) against a bump of the pricer; a second
+    # difference needs a wider step for gamma.
+    for forward, strike, ttm, vol, _ in CASES:
+        h = 1e-4
+        vega = compute_bsm_vanilla_vega(ttm, forward, strike, vol)
+        vega_fd = (compute_bsm_vanilla_price(forward, strike, ttm, vol + h, 'C')
+                   - compute_bsm_vanilla_price(forward, strike, ttm, vol - h, 'C')) / (2.0 * h)
+        assert abs(vega - vega_fd) < 1e-3
+
+        gamma = compute_bsm_vanilla_gamma(ttm, forward, strike, vol)
+        hg = 1e-2
+        gamma_fd = (compute_bsm_vanilla_price(forward + hg, strike, ttm, vol, 'C')
+                    - 2.0 * compute_bsm_vanilla_price(forward, strike, ttm, vol, 'C')
+                    + compute_bsm_vanilla_price(forward - hg, strike, ttm, vol, 'C')) / hg ** 2
+        assert abs(gamma - gamma_fd) < 1e-3
+
+        for optiontype in ('C', 'P'):
+            delta = compute_bsm_vanilla_delta(ttm, forward, strike, vol, optiontype)
+            up = compute_bsm_vanilla_price(forward + h, strike, ttm, vol, optiontype)
+            down = compute_bsm_vanilla_price(forward - h, strike, ttm, vol, optiontype)
+            assert abs(delta - (up - down) / (2.0 * h)) < 1e-4


### PR DESCRIPTION
`compute_bsm_vanilla_theta` builds the volatility-decay term as

    -forward * npdf(d1)*vol/(0.5*np.sqrt(ttm))

`vol/(0.5*sqrt(ttm))` equals `2*vol/sqrt(ttm)`, but the Black decay term is
`F*n(d1)*vol/(2*sqrt(ttm))`, so it comes out 4x too large — a `1/(2*sqrt(T))` written as
`1/(0.5*sqrt(T))`. That same term is also missing the `discfactor` the rate term already
carries, so at a nonzero rate it is off by that factor as well. Theta is wrong in every
regime, and both the call and put branches are affected.

Fix: `0.5 -> 2.0` in the denominator and add the leading `discfactor`.

Repro on the current code:

    from vanilla_option_pricers.black_scholes import (
        compute_bsm_vanilla_price, compute_bsm_vanilla_theta)
    F = K = 100.0; T = 1.0; vol = 0.2
    fd = -(compute_bsm_vanilla_price(F, K, T + 1e-6, vol, 'C')
           - compute_bsm_vanilla_price(F, K, T - 1e-6, vol, 'C')) / 2e-6
    theta = compute_bsm_vanilla_theta(T, F, K, vol, 'C', 1.0, 0.0)
    print(theta, fd, theta / fd)   # -15.878 -3.970 4.0

I also added `vanilla_option_pricers/tests/test_black_scholes.py`, the first numerical
test module. It checks put-call parity and compares each greek against a finite
difference of the pricer itself, so the pricer is the reference (numpy only, no new
deps). Theta is taken with spot held fixed — forward and discount factor both move with
ttm, which is the discounting the analytic formula assumes — so that one check pins both
corrections at once. Before the fix the two theta tests fail (analytic/FD ~ 4); after,
all pass. delta, vega and gamma already agree with the finite difference and are kept as
regression checks. I cross-checked the corrected theta against QuantLib's analytic
European engine separately (matches to rounding); the shipped test stays numpy-only per
the no-scipy rule.

The identical decay term appears in stochvolmodels; happy to send the same fix there if
this looks right.