### PR TITLE
Align public surface and frequent PyPI publishing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,23 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Keep repository text portable; never normalise binary assets.
+* text=auto eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.rst text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.json text eol=lf
+*.png binary
+*.PNG binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary
+*.npz binary
+*.npy binary
+*.xlsx binary
+*.xls binary
+*.docx binary
+*.pkl binary
+*.pickle binary
+*.parquet binary

--- a/.github/scripts/check_stack_imports.py
+++ b/.github/scripts/check_stack_imports.py
@@ -1,0 +1,252 @@
+"""Check stack dependencies and optional import boundaries without importing source."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+def module_imports(tree):
+    """Yield imports executed by a module body, including class/try/if bodies."""
+
+    def walk(node):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            return
+        if isinstance(node, ast.If) and (
+            isinstance(node.test, ast.Name)
+            and node.test.id == "TYPE_CHECKING"
+            or isinstance(node.test, ast.Attribute)
+            and node.test.attr == "TYPE_CHECKING"
+        ):
+            for child in node.orelse:
+                yield from walk(child)
+            return
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            yield node
+        for child in ast.iter_child_nodes(node):
+            yield from walk(child)
+
+    yield from walk(tree)
+
+
+def names(node):
+    """Return absolute import names; relative imports are internal graph edges."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    return [node.module or ""] if not node.level else []
+
+
+def permitted(path, module, rules, function=None):
+    """Exceptions name both a source path and the optional module it may load."""
+    return any(
+        fnmatch.fnmatchcase(path, rule["path"])
+        and module in rule["modules"]
+        and ("function" not in rule or rule["function"] == function)
+        for rule in rules
+    )
+
+
+def audit(root, policy):
+    """Return concrete violations and the number of parsed package modules."""
+    package_root = root / "src" / policy["import"]
+    modules = {}
+    for path in package_root.rglob("*.py"):
+        relative = path.relative_to(root).as_posix()
+        name = ".".join(path.relative_to(root / "src").with_suffix("").parts)
+        if name.endswith(".__init__"):
+            name = name[:-9]
+        modules[name] = (
+            relative,
+            ast.parse(path.read_text(encoding="utf-8-sig"), filename=relative),
+        )
+    errors, graph, isolated = [], {}, set()
+    forbidden = set(policy["forbidden"])
+    optional = set(policy["optional"])
+    for module, (path, tree) in modules.items():
+        parents = {
+            child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                parent, function = node, None
+                while parent in parents:
+                    parent = parents[parent]
+                    if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        function = parent.name
+                        break
+                for imported in names(node):
+                    top = imported.split(".")[0]
+                    if top in forbidden and not permitted(
+                        path, top, policy["development_imports"], function
+                    ):
+                        errors.append(f"{path}:{node.lineno}: forbidden stack import {top}")
+        top_level = list(module_imports(tree))
+        edges = set()
+        for node in top_level:
+            for imported in names(node):
+                top = imported.split(".")[0]
+                if top in optional:
+                    if permitted(path, top, policy["optional_adapters"]):
+                        isolated.add(module)
+                    else:
+                        errors.append(
+                            f"{path}:{node.lineno}: optional stack import {top} at module level"
+                        )
+            targets = []
+            if isinstance(node, ast.Import):
+                targets = [alias.name for alias in node.names]
+            elif not node.level:
+                targets = [node.module or ""] + [
+                    f"{node.module}.{alias.name}" for alias in node.names
+                ]
+            else:
+                package = module if path.endswith("/__init__.py") else module.rpartition(".")[0]
+                parts = package.split(".")
+                base = ".".join(parts[: len(parts) - node.level + 1])
+                target = ".".join(part for part in (base, node.module) if part)
+                targets = [target] + [f"{target}.{alias.name}" for alias in node.names]
+            for target in targets:
+                pieces = target.split(".")
+                edges.update(
+                    ".".join(pieces[:i])
+                    for i in range(1, len(pieces) + 1)
+                    if ".".join(pieces[:i]) in modules
+                )
+        graph[module] = edges
+    pending, visited = [policy["import"]], set()
+    while pending:
+        module = pending.pop()
+        if module in visited:
+            continue
+        visited.add(module)
+        pending.extend(graph.get(module, set()) - visited)
+    for module in sorted(isolated & visited):
+        errors.append(
+            f"{modules[module][0]}: optional adapter is reachable during package-root import"
+        )
+    return sorted(set(errors)), len(modules)
+
+
+def check_root(root, policy):
+    """Test root import in a fresh process while recording blocked optional imports."""
+    if not policy["optional"]:
+        return
+    probe = """import importlib.abc, json, sys
+optional, source, package = json.loads(sys.argv[1])
+attempts = []
+class BlockOptional(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split('.')[0] in optional:
+            attempts.append(fullname)
+            raise ModuleNotFoundError('optional stack import blocked: ' + fullname)
+sys.meta_path.insert(0, BlockOptional())
+sys.path.insert(0, source)
+__import__(package)
+if attempts:
+    raise SystemExit('package-root import attempted optional modules: ' + ', '.join(attempts))
+"""
+    subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-c",
+            probe,
+            json.dumps([policy["optional"], str(root / "src"), policy["import"]]),
+        ],
+        cwd=root,
+        check=True,
+    )
+
+
+class BoundaryTests(unittest.TestCase):
+    """Known-bad imports, allowed local loads, and adapter leakage regressions."""
+
+    def check_source(self, source, adapter=None, exception=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = root / "src/pkg"
+            package.mkdir(parents=True)
+            (package / "__init__.py").write_text(source, encoding="utf-8")
+            if adapter is not None:
+                (package / "adapter.py").write_text(adapter, encoding="utf-8")
+            policy = {
+                "import": "pkg",
+                "optional": ["optional_stack"],
+                "forbidden": ["forbidden_stack"],
+                "development_imports": [],
+                "optional_adapters": [{"path": "src/pkg/adapter.py", "modules": ["optional_stack"]}]
+                if exception
+                else [],
+            }
+            return audit(root, policy)[0]
+
+    def test_module_scope_is_rejected(self):
+        self.assertTrue(self.check_source("import optional_stack\n"))
+
+    def test_function_local_import_is_allowed(self):
+        self.assertFalse(self.check_source("def load():\n    import optional_stack\n"))
+
+    def test_guarded_module_import_is_still_rejected(self):
+        self.assertTrue(
+            self.check_source("try:\n    import optional_stack\nexcept ImportError:\n    pass\n")
+        )
+
+    def test_type_checking_only_import_is_allowed(self):
+        self.assertFalse(
+            self.check_source(
+                "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    import optional_stack\n"
+            )
+        )
+
+    def test_isolated_named_adapter_is_allowed(self):
+        self.assertFalse(self.check_source("", "import optional_stack\n", True))
+
+    def test_root_reachable_adapter_is_rejected(self):
+        self.assertTrue(
+            self.check_source("from . import adapter\n", "import optional_stack\n", True)
+        )
+
+    def test_forbidden_import_is_not_hidden_by_local_scope(self):
+        self.assertTrue(self.check_source("def load():\n    import forbidden_stack\n"))
+
+    def test_maintainer_exception_requires_named_function_and_module(self):
+        rules = [
+            {"path": "src/pkg/universe.py", "function": "generate_data", "modules": ["bbg_fetch"]}
+        ]
+        self.assertTrue(permitted("src/pkg/universe.py", "bbg_fetch", rules, "generate_data"))
+        self.assertFalse(permitted("src/pkg/universe.py", "bbg_fetch", rules, "other"))
+        self.assertFalse(permitted("src/pkg/universe.py", "qis", rules, "generate_data"))
+
+
+def main():
+    """Run static policy, optional root-import probe, or the self-contained tests."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--check-root", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        result = unittest.TextTestRunner(verbosity=2).run(
+            unittest.defaultTestLoader.loadTestsFromTestCase(BoundaryTests)
+        )
+        return 0 if result.wasSuccessful() else 1
+    policy = json.loads((args.root / ".github/stack-policy.json").read_text(encoding="utf-8"))
+    errors, count = audit(args.root, policy)
+    if errors:
+        print("\n".join(errors))
+        return 1
+    if args.check_root:
+        check_root(args.root, policy)
+    print(f"Stack import policy passed ({count} modules)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_tag.py
+++ b/.github/scripts/publish_tag.py
@@ -1,0 +1,46 @@
+"""Validate a prepared release; --push creates/pushes only its named tag.
+
+Run after the release metadata commit is on origin/main. This does not build locally,
+create an environment, upload a package, or create a GitHub Release page. The pushed
+tag triggers release.yml. Omitting --push is a read-only dry run.
+"""
+import argparse
+import subprocess
+from pathlib import Path
+
+from release_guard import run, validate_metadata
+
+
+def main() -> None:
+    """Require a clean main commit and matching remote identity before a named tag push."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag")
+    parser.add_argument("--push", action="store_true")
+    args = parser.parse_args()
+    root = Path(run("git", "rev-parse", "--show-toplevel"))
+    project = validate_metadata(root, args.tag)
+    if run("git", "status", "--porcelain", cwd=root):
+        raise SystemExit("Commit the intended changes first; the release checkout must be clean")
+    if run("git", "branch", "--show-current", cwd=root) != "main":
+        raise SystemExit("Run this helper from main after merging the release metadata")
+    sha = run("git", "rev-parse", "HEAD", cwd=root)
+    print(f"{project['name']} {project['version']}: {args.tag} -> {sha}")
+    if not args.push:
+        print("Dry run. --push verifies remote main, creates the named tag if absent, and pushes it.")
+        return
+    remote = run("git", "ls-remote", "origin", "refs/heads/main", cwd=root).split()
+    if not remote or remote[0] != sha:
+        raise SystemExit("Push the verified main commit before requesting its release tag")
+    existing = subprocess.run(["git", "rev-parse", "--verify", f"refs/tags/{args.tag}^{{commit}}"],
+                              cwd=root, capture_output=True, text=True)
+    if existing.returncode == 0:
+        if existing.stdout.strip() != sha:
+            raise SystemExit("Existing tag points elsewhere; refusing to move it")
+    else:
+        run("git", "tag", "-a", args.tag, "-m", f"Release {project['version']}", cwd=root)
+    run("git", "push", "origin", f"refs/tags/{args.tag}:refs/tags/{args.tag}", cwd=root)
+    print("Named tag pushed. Follow the Publish package workflow; GitHub Release page is optional.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/publish_tag.py
+++ b/.github/scripts/publish_tag.py
@@ -4,6 +4,7 @@ Run after the release metadata commit is on origin/main. This does not build loc
 create an environment, upload a package, or create a GitHub Release page. The pushed
 tag triggers release.yml. Omitting --push is a read-only dry run.
 """
+
 import argparse
 import subprocess
 from pathlib import Path
@@ -26,13 +27,19 @@ def main() -> None:
     sha = run("git", "rev-parse", "HEAD", cwd=root)
     print(f"{project['name']} {project['version']}: {args.tag} -> {sha}")
     if not args.push:
-        print("Dry run. --push verifies remote main, creates the named tag if absent, and pushes it.")
+        print(
+            "Dry run. --push verifies remote main, creates the named tag if absent, and pushes it."
+        )
         return
     remote = run("git", "ls-remote", "origin", "refs/heads/main", cwd=root).split()
     if not remote or remote[0] != sha:
         raise SystemExit("Push the verified main commit before requesting its release tag")
-    existing = subprocess.run(["git", "rev-parse", "--verify", f"refs/tags/{args.tag}^{{commit}}"],
-                              cwd=root, capture_output=True, text=True)
+    existing = subprocess.run(
+        ["git", "rev-parse", "--verify", f"refs/tags/{args.tag}^{{commit}}"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
     if existing.returncode == 0:
         if existing.stdout.strip() != sha:
             raise SystemExit("Existing tag points elsewhere; refusing to move it")

--- a/.github/scripts/release_guard.py
+++ b/.github/scripts/release_guard.py
@@ -3,6 +3,7 @@
 This helper never publishes packages or creates GitHub Release pages. GitHub builds
 are isolated from the OIDC publishing job. All subprocess arguments are structured.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -34,8 +35,15 @@ def version_from_tag(tag: str) -> str:
 
 def run(*args: str, cwd: Path | None = None) -> str:
     """Run an explicit command and return stdout with a bounded runtime."""
-    return subprocess.run(list(args), cwd=cwd, check=True, text=True,
-                          encoding="utf-8", capture_output=True, timeout=1800).stdout.strip()
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=True,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        timeout=1800,
+    ).stdout.strip()
 
 
 def cff_scalar(source: str, key: str) -> str:
@@ -119,7 +127,11 @@ def inspect_artifacts(dist: Path, project: dict, import_name: str) -> dict[str, 
         wheel_paths = set(wheel.namelist())
         wheel_metadata_root = metadata_names[0].rsplit("/", 1)[0]
     with tarfile.open(sdists[0], "r:gz") as archive:
-        candidates = [m for m in archive.getmembers() if m.name.count("/") == 1 and m.name.endswith("/PKG-INFO")]
+        candidates = [
+            m
+            for m in archive.getmembers()
+            if m.name.count("/") == 1 and m.name.endswith("/PKG-INFO")
+        ]
         if len(candidates) != 1:
             raise ValueError("Sdist lacks unique top-level PKG-INFO")
         sdist_metadata = archive.extractfile(candidates[0]).read().decode("utf-8")
@@ -128,17 +140,39 @@ def inspect_artifacts(dist: Path, project: dict, import_name: str) -> dict[str, 
     source_paths = {name.removeprefix(sdist_root + "/") for name in sdist_paths}
     if f"src/{import_name}/__init__.py" not in source_paths:
         raise ValueError("Sdist lacks the expected source package")
-    prohibited = {".idea", ".git", ".venv", "venv", "__pycache__", ".pytest_cache",
-                  ".ruff_cache", ".mypy_cache", "run_local"}
+    prohibited = {
+        ".idea",
+        ".git",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "run_local",
+    }
     for archive_name, paths in (("Wheel", wheel_paths), ("Sdist", source_paths)):
         for name in paths:
             parts = PurePosixPath(name).parts
-            runner = import_name in {"privateassets", "goal_based_allocation"} and import_name in parts and "run" in parts
-            if prohibited.intersection(parts) or name.endswith((".pyc", ".pyo", ".nbc", ".nbi")) or runner:
-                raise ValueError(f"{archive_name} contains a development runner, environment or cache: {name}")
+            runner = (
+                import_name in {"privateassets", "goal_based_allocation"}
+                and import_name in parts
+                and "run" in parts
+            )
+            if (
+                prohibited.intersection(parts)
+                or name.endswith((".pyc", ".pyo", ".nbc", ".nbi"))
+                or runner
+            ):
+                raise ValueError(
+                    f"{archive_name} contains a development runner, environment or cache: {name}"
+                )
     for metadata in (wheel_metadata, sdist_metadata):
         parsed = email.parser.Parser().parsestr(metadata)
-        if normalized(parsed["Name"]) != normalized(project["name"]) or parsed["Version"] != project["version"]:
+        if (
+            normalized(parsed["Name"]) != normalized(project["name"])
+            or parsed["Version"] != project["version"]
+        ):
             raise ValueError("Built artifact identity differs from source/tag")
         if parsed["Summary"] != project["description"]:
             raise ValueError("Built artifact summary differs from source")
@@ -147,11 +181,16 @@ def inspect_artifacts(dist: Path, project: dict, import_name: str) -> dict[str, 
             raise ValueError("Built artifact project URLs differ from source")
         if parsed["Requires-Python"] != project.get("requires-python"):
             raise ValueError("Built artifact Requires-Python differs from source")
-        core = {requirement_key(value) for value in parsed.get_all("Requires-Dist", [])
-                if not re.search(r"\bextra\s*==", value)}
+        core = {
+            requirement_key(value)
+            for value in parsed.get_all("Requires-Dist", [])
+            if not re.search(r"\bextra\s*==", value)
+        }
         if core != {requirement_key(value) for value in project.get("dependencies", [])}:
             raise ValueError("Built artifact core dependency metadata differs from source")
-        if set(parsed.get_all("Provides-Extra", [])) != set(project.get("optional-dependencies", {})):
+        if set(parsed.get_all("Provides-Extra", [])) != set(
+            project.get("optional-dependencies", {})
+        ):
             raise ValueError("Built artifact extra names differ from source")
         if isinstance(project.get("license"), str):
             if parsed["License-Expression"] != project["license"]:
@@ -160,15 +199,22 @@ def inspect_artifacts(dist: Path, project: dict, import_name: str) -> dict[str, 
             if not licenses:
                 raise ValueError("Built artifact declares no shipped license file")
             for license_file in licenses:
-                if f"{wheel_metadata_root}/licenses/{license_file}" not in wheel_paths or f"{sdist_root}/{license_file}" not in sdist_paths:
-                    raise ValueError(f"Declared license file is missing from wheel or sdist: {license_file}")
+                if (
+                    f"{wheel_metadata_root}/licenses/{license_file}" not in wheel_paths
+                    or f"{sdist_root}/{license_file}" not in sdist_paths
+                ):
+                    raise ValueError(
+                        f"Declared license file is missing from wheel or sdist: {license_file}"
+                    )
     return {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in wheels + sdists}
 
 
 def pypi_files(name: str, version: str) -> list[dict] | None:
     """A confirmed 404 means new version; every other API error blocks publication."""
-    request = urllib.request.Request(f"https://pypi.org/pypi/{name}/{version}/json",
-                                     headers={"User-Agent": "ArturSepp-release-v1"})
+    request = urllib.request.Request(
+        f"https://pypi.org/pypi/{name}/{version}/json",
+        headers={"User-Agent": "ArturSepp-release-v1"},
+    )
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             data = json.load(response)
@@ -181,8 +227,9 @@ def pypi_files(name: str, version: str) -> list[dict] | None:
     return data["urls"]
 
 
-def pending_uploads(hashes: dict[str, str], existing: list[dict] | None,
-                    retry_existing: bool = False) -> list[str]:
+def pending_uploads(
+    hashes: dict[str, str], existing: list[dict] | None, retry_existing: bool = False
+) -> list[str]:
     """Require matching digests; backfill tag pushes never append historical files."""
     if existing is None:
         return sorted(hashes)
@@ -196,7 +243,10 @@ def pending_uploads(hashes: dict[str, str], existing: list[dict] | None,
             raise ValueError(f"Immutable PyPI artifact differs: {name}; never skip this mismatch")
     pending = sorted(hashes.keys() - remote.keys())
     if pending and not retry_existing:
-        raise ValueError("Existing version is incomplete: use explicit retry_existing dispatch after digest review")
+        raise ValueError(
+            "Existing version is incomplete: use explicit retry_existing dispatch "
+            "after digest review"
+        )
     return pending
 
 
@@ -223,9 +273,14 @@ def main() -> None:
     parser.add_argument("--retry-existing", action="store_true")
     args = parser.parse_args()
     if args.command == "checkout":
-        if os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch" and os.environ.get("GITHUB_REF") != "refs/heads/main":
+        if (
+            os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch"
+            and os.environ.get("GITHUB_REF") != "refs/heads/main"
+        ):
             raise ValueError("Dispatch publishing from the main workflow only")
-        expected = os.environ.get("GITHUB_SHA") if os.environ.get("GITHUB_EVENT_NAME") == "push" else None
+        expected = (
+            os.environ.get("GITHUB_SHA") if os.environ.get("GITHUB_EVENT_NAME") == "push" else None
+        )
         result = checkout_tag(args.root, args.tag, expected)
         if os.environ.get("GITHUB_ENV"):
             with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as stream:
@@ -239,11 +294,25 @@ def main() -> None:
             parser.error("artifacts requires --dist, --pending, --import-name")
         project = validate_metadata(args.root, args.tag)
         hashes = inspect_artifacts(args.dist, project, args.import_name)
-        pending = pending_uploads(hashes, pypi_files(project["name"], project["version"]), args.retry_existing)
+        pending = pending_uploads(
+            hashes, pypi_files(project["name"], project["version"]), args.retry_existing
+        )
         args.pending.mkdir(parents=True, exist_ok=False)
         for filename in pending:
             shutil.copy2(args.dist / filename, args.pending / filename)
-        (args.dist / "release-manifest.json").write_text(json.dumps({"tag": args.tag, "sha": run("git", "rev-parse", "HEAD", cwd=args.root), "sha256": hashes, "pending": pending}, indent=2) + "\n", encoding="utf-8")
+        (args.dist / "release-manifest.json").write_text(
+            json.dumps(
+                {
+                    "tag": args.tag,
+                    "sha": run("git", "rev-parse", "HEAD", cwd=args.root),
+                    "sha256": hashes,
+                    "pending": pending,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         output({"publish": "true" if pending else "false", "pending_count": len(pending)})
 
 

--- a/.github/scripts/release_guard.py
+++ b/.github/scripts/release_guard.py
@@ -1,0 +1,251 @@
+"""Release-v1: validate one tag, inspect built artifacts and plan digest-safe uploads.
+
+This helper never publishes packages or creates GitHub Release pages. GitHub builds
+are isolated from the OIDC publishing job. All subprocess arguments are structured.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import email.parser
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tomllib
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+TAG_RE = re.compile(r"v(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?)")
+
+
+def version_from_tag(tag: str) -> str:
+    """Reject refs, shell fragments, wildcard tags and ambiguous version syntax."""
+    match = TAG_RE.fullmatch(tag)
+    if not match:
+        raise ValueError("Expected a named tag such as v1.2.3, v1.2.3rc1 or v1.2.3.dev1")
+    return match[1]
+
+
+def run(*args: str, cwd: Path | None = None) -> str:
+    """Run an explicit command and return stdout with a bounded runtime."""
+    return subprocess.run(list(args), cwd=cwd, check=True, text=True,
+                          encoding="utf-8", capture_output=True, timeout=1800).stdout.strip()
+
+
+def cff_scalar(source: str, key: str) -> str:
+    """Read a simple scalar and reject duplicate/multiline ambiguous release values."""
+    values = re.findall(rf"^{re.escape(key)}:\s*([^\n]+)$", source, flags=re.MULTILINE)
+    if len(values) != 1:
+        raise ValueError(f"CITATION.cff requires one {key}")
+    value = values[0].strip().split(" #", 1)[0].strip()
+    if value.startswith('"'):
+        return json.loads(value)
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1].replace("''", "'")
+    if not re.fullmatch(r"[0-9A-Za-z.+-]+", value):
+        raise ValueError(f"Unsupported CFF {key} scalar")
+    return value
+
+
+def validate_metadata(root: Path, tag: str) -> dict:
+    """Validate source release identity and the recorded intended release date."""
+    version = version_from_tag(tag)
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    if project["version"] != version:
+        raise ValueError(f"Tag {tag} differs from project version {project['version']}")
+    cff = (root / "CITATION.cff").read_text(encoding="utf-8")
+    if cff_scalar(cff, "version") != version:
+        raise ValueError("CITATION.cff version differs from tag")
+    intended = dt.date.fromisoformat(cff_scalar(cff, "date-released"))
+    if intended > dt.datetime.now(dt.timezone.utc).date():
+        raise ValueError("CITATION.cff intended release date is in the future")
+    changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    pattern = rf"^##\s+(?:\[{re.escape(version)}\]|{re.escape(version)})(?:\s+.*)?$"
+    if not re.search(pattern, changelog, flags=re.MULTILINE):
+        raise ValueError("CHANGELOG.md has no heading for the tagged version")
+    return project
+
+
+def checkout_tag(root: Path, tag: str, expected_sha: str | None = None) -> dict:
+    """Resolve and check ancestry before checking out exactly one release commit."""
+    version_from_tag(tag)
+    sha = run("git", "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}", cwd=root)
+    if expected_sha is not None:
+        if not re.fullmatch(r"[0-9a-f]{40}", expected_sha):
+            raise ValueError("Invalid triggering object SHA")
+        triggered = run("git", "rev-parse", "--verify", f"{expected_sha}^{{commit}}", cwd=root)
+        if triggered != sha:
+            raise ValueError("Tag moved after the triggering push; refusing a different commit")
+    run("git", "merge-base", "--is-ancestor", sha, "refs/remotes/origin/main", cwd=root)
+    run("git", "checkout", "--detach", sha, cwd=root)
+    if run("git", "rev-parse", "HEAD", cwd=root) != sha:
+        raise ValueError("Checkout does not match the resolved tag")
+    project = validate_metadata(root, tag)
+    epoch = run("git", "show", "-s", "--format=%ct", sha, cwd=root)
+    return {"sha": sha, "version": project["version"], "epoch": epoch}
+
+
+def normalized(name: str) -> str:
+    """Normalize a PyPI distribution name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def requirement_key(requirement: str) -> str:
+    """Canonicalize names and specifier order for the stack's core requirements."""
+    match = re.fullmatch(r"([A-Za-z0-9_.-]+)(\[[^]]+\])?([^;]*)(?:;(.*))?", requirement.strip())
+    if not match:
+        raise ValueError(f"Unsupported requirement metadata: {requirement}")
+    specifiers = ",".join(sorted(x.strip() for x in match[3].split(",") if x.strip()))
+    marker = re.sub(r"\s+", "", match[4] or "").replace("'", '"')
+    return normalized(match[1]) + (match[2] or "") + specifiers + (";" + marker if marker else "")
+
+
+def inspect_artifacts(dist: Path, project: dict, import_name: str) -> dict[str, str]:
+    """Check one wheel plus one sdist and compute immutable filename/hash identity."""
+    wheels, sdists = list(dist.glob("*.whl")), list(dist.glob("*.tar.gz"))
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ValueError("Expected exactly one wheel and one source distribution")
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        metadata_names = [n for n in wheel.namelist() if n.endswith(".dist-info/METADATA")]
+        if len(metadata_names) != 1 or f"{import_name}/__init__.py" not in wheel.namelist():
+            raise ValueError("Wheel lacks the expected package or unique METADATA")
+        wheel_metadata = wheel.read(metadata_names[0]).decode("utf-8")
+        wheel_paths = set(wheel.namelist())
+        wheel_metadata_root = metadata_names[0].rsplit("/", 1)[0]
+    with tarfile.open(sdists[0], "r:gz") as archive:
+        candidates = [m for m in archive.getmembers() if m.name.count("/") == 1 and m.name.endswith("/PKG-INFO")]
+        if len(candidates) != 1:
+            raise ValueError("Sdist lacks unique top-level PKG-INFO")
+        sdist_metadata = archive.extractfile(candidates[0]).read().decode("utf-8")
+        sdist_paths = set(archive.getnames())
+        sdist_root = candidates[0].name.split("/", 1)[0]
+    source_paths = {name.removeprefix(sdist_root + "/") for name in sdist_paths}
+    if f"src/{import_name}/__init__.py" not in source_paths:
+        raise ValueError("Sdist lacks the expected source package")
+    prohibited = {".idea", ".git", ".venv", "venv", "__pycache__", ".pytest_cache",
+                  ".ruff_cache", ".mypy_cache", "run_local"}
+    for archive_name, paths in (("Wheel", wheel_paths), ("Sdist", source_paths)):
+        for name in paths:
+            parts = PurePosixPath(name).parts
+            runner = import_name in {"privateassets", "goal_based_allocation"} and import_name in parts and "run" in parts
+            if prohibited.intersection(parts) or name.endswith((".pyc", ".pyo", ".nbc", ".nbi")) or runner:
+                raise ValueError(f"{archive_name} contains a development runner, environment or cache: {name}")
+    for metadata in (wheel_metadata, sdist_metadata):
+        parsed = email.parser.Parser().parsestr(metadata)
+        if normalized(parsed["Name"]) != normalized(project["name"]) or parsed["Version"] != project["version"]:
+            raise ValueError("Built artifact identity differs from source/tag")
+        if parsed["Summary"] != project["description"]:
+            raise ValueError("Built artifact summary differs from source")
+        urls = dict(value.split(", ", 1) for value in parsed.get_all("Project-URL", []))
+        if urls != project.get("urls", {}):
+            raise ValueError("Built artifact project URLs differ from source")
+        if parsed["Requires-Python"] != project.get("requires-python"):
+            raise ValueError("Built artifact Requires-Python differs from source")
+        core = {requirement_key(value) for value in parsed.get_all("Requires-Dist", [])
+                if not re.search(r"\bextra\s*==", value)}
+        if core != {requirement_key(value) for value in project.get("dependencies", [])}:
+            raise ValueError("Built artifact core dependency metadata differs from source")
+        if set(parsed.get_all("Provides-Extra", [])) != set(project.get("optional-dependencies", {})):
+            raise ValueError("Built artifact extra names differ from source")
+        if isinstance(project.get("license"), str):
+            if parsed["License-Expression"] != project["license"]:
+                raise ValueError("Built artifact License-Expression differs from source")
+            licenses = parsed.get_all("License-File", [])
+            if not licenses:
+                raise ValueError("Built artifact declares no shipped license file")
+            for license_file in licenses:
+                if f"{wheel_metadata_root}/licenses/{license_file}" not in wheel_paths or f"{sdist_root}/{license_file}" not in sdist_paths:
+                    raise ValueError(f"Declared license file is missing from wheel or sdist: {license_file}")
+    return {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in wheels + sdists}
+
+
+def pypi_files(name: str, version: str) -> list[dict] | None:
+    """A confirmed 404 means new version; every other API error blocks publication."""
+    request = urllib.request.Request(f"https://pypi.org/pypi/{name}/{version}/json",
+                                     headers={"User-Agent": "ArturSepp-release-v1"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            data = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    if not isinstance(data, dict) or not isinstance(data.get("urls"), list) or not data["urls"]:
+        raise ValueError("PyPI returned an unexpected or empty artifact list")
+    return data["urls"]
+
+
+def pending_uploads(hashes: dict[str, str], existing: list[dict] | None,
+                    retry_existing: bool = False) -> list[str]:
+    """Require matching digests; backfill tag pushes never append historical files."""
+    if existing is None:
+        return sorted(hashes)
+    remote = {f["filename"]: f["digests"]["sha256"] for f in existing}
+    if len(remote) != len(existing):
+        raise ValueError("Duplicate PyPI artifact filenames")
+    if not remote.keys() <= hashes.keys():
+        raise ValueError("Existing release has unexpected artifact filenames")
+    for name, digest in remote.items():
+        if hashes[name] != digest:
+            raise ValueError(f"Immutable PyPI artifact differs: {name}; never skip this mismatch")
+    pending = sorted(hashes.keys() - remote.keys())
+    if pending and not retry_existing:
+        raise ValueError("Existing version is incomplete: use explicit retry_existing dispatch after digest review")
+    return pending
+
+
+def output(values: dict) -> None:
+    """Emit simple validated GitHub outputs and a readable local result."""
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as stream:
+            for key, value in values.items():
+                if "\n" in str(value):
+                    raise ValueError("Multiline output is not allowed")
+                stream.write(f"{key}={value}\n")
+    print(json.dumps(values, indent=2))
+
+
+def main() -> None:
+    """Run only the explicit stage selected by the workflow or local maintainer."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["checkout", "check", "artifacts"])
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--dist", type=Path)
+    parser.add_argument("--import-name")
+    parser.add_argument("--pending", type=Path)
+    parser.add_argument("--retry-existing", action="store_true")
+    args = parser.parse_args()
+    if args.command == "checkout":
+        if os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch" and os.environ.get("GITHUB_REF") != "refs/heads/main":
+            raise ValueError("Dispatch publishing from the main workflow only")
+        expected = os.environ.get("GITHUB_SHA") if os.environ.get("GITHUB_EVENT_NAME") == "push" else None
+        result = checkout_tag(args.root, args.tag, expected)
+        if os.environ.get("GITHUB_ENV"):
+            with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as stream:
+                stream.write(f"SOURCE_DATE_EPOCH={result['epoch']}\n")
+        output(result)
+    elif args.command == "check":
+        project = validate_metadata(args.root, args.tag)
+        output({"name": project["name"], "version": project["version"]})
+    else:
+        if not args.dist or not args.pending or not args.import_name:
+            parser.error("artifacts requires --dist, --pending, --import-name")
+        project = validate_metadata(args.root, args.tag)
+        hashes = inspect_artifacts(args.dist, project, args.import_name)
+        pending = pending_uploads(hashes, pypi_files(project["name"], project["version"]), args.retry_existing)
+        args.pending.mkdir(parents=True, exist_ok=False)
+        for filename in pending:
+            shutil.copy2(args.dist / filename, args.pending / filename)
+        (args.dist / "release-manifest.json").write_text(json.dumps({"tag": args.tag, "sha": run("git", "rev-parse", "HEAD", cwd=args.root), "sha256": hashes, "pending": pending}, indent=2) + "\n", encoding="utf-8")
+        output({"publish": "true" if pending else "false", "pending_count": len(pending)})
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/stack-policy.json
+++ b/.github/stack-policy.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "source_registry": "ArturSepp/scripts/public_registry.json",
+  "import": "vanilla_option_pricers",
+  "core": [],
+  "optional": [],
+  "forbidden": [
+    "bbg_fetch",
+    "factorlasso",
+    "goal_based_allocation",
+    "optimalportfolios",
+    "option_chain_analytics",
+    "privateassets",
+    "qis",
+    "stochvolmodels",
+    "trendfollowing"
+  ],
+  "optional_adapters": [],
+  "development_imports": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.12"
+          enable-cache: false
       - name: Exercise policy regressions
         run: python .github/scripts/check_stack_imports.py --self-test
       - name: Check stack imports and optional adapter isolation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,38 @@ jobs:
         cp "$GITHUB_WORKSPACE/examples/getting_started/pricing_and_iv.py" .
         python pricing_and_iv.py
         python -c "from pathlib import Path; import vanilla_option_pricers as package; checkout = Path(r'${{ github.workspace }}').resolve(); package_path = Path(package.__file__).resolve(); assert not package_path.is_relative_to(checkout), (checkout, package_path); print(f'wheel_import={package_path}')"
+
+  stack-policy:
+    name: stack import boundaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+      - name: Exercise policy regressions
+        run: python .github/scripts/check_stack_imports.py --self-test
+      - name: Check stack imports and optional adapter isolation
+        run: python .github/scripts/check_stack_imports.py
+
+  lowest-dependencies:
+    name: lowest direct dependencies (Python 3.10)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.10"
+      - name: Keep the test environment outside the checkout
+        run: echo "UV_PROJECT_ENVIRONMENT=$RUNNER_TEMP/lowest-dependencies" >> "$GITHUB_ENV"
+      - name: Resolve a fresh lowest-direct test environment
+        # Upgrade ignores lockfile preference; this job never commits its experimental lock.
+        run: uv sync --python 3.10 --resolution lowest-direct --upgrade --group test
+      - name: Record installed versions
+        run: uv pip freeze --python "$UV_PROJECT_ENVIRONMENT/bin/python"
+      - name: Check optional dependencies stay outside package-root import
+        run: uv run --no-sync python .github/scripts/check_stack_imports.py --check-root
+      - name: Test declared dependency floors without live provider credentials
+        run: uv run --no-sync pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+# SHARED CI CORE v1.2 — T1 — synced 2026-09-08 — template release-v1
+name: Publish package
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing named tag to validate and publish
+        required: true
+        type: string
+      retry_existing:
+        description: Complete a partial existing upload only after matching its artifact hashes
+        default: false
+        type: boolean
+      github_release:
+        description: Also create an optional GitHub Release page
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+concurrency:
+  group: publish-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  MPLBACKEND: Agg
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      publish: ${{ steps.artifacts.outputs.publish }}
+      sha: ${{ steps.identity.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+      - name: Resolve the tag and validate release identity
+        id: identity
+        run: |
+          cp .github/scripts/release_guard.py "$RUNNER_TEMP/release_guard.py"
+          python "$RUNNER_TEMP/release_guard.py" checkout --tag "$RELEASE_TAG"
+      - name: Run the tagged source test suite
+        run: |
+          uv sync --locked --group test
+          uv run --no-sync pytest
+      - name: Build the tagged documentation with warnings as errors
+        run: |
+          uv sync --locked --extra docs
+          uv run --no-sync python -m sphinx -E -W --keep-going -b html docs "$RUNNER_TEMP/release-docs"
+      - name: Build one sdist and its wheel
+        run: |
+          uv build --sdist --out-dir "$RUNNER_TEMP/release-dist"
+          uv build --wheel "$RUNNER_TEMP/release-dist/"*.tar.gz --out-dir "$RUNNER_TEMP/release-dist"
+          uvx --from twine twine check "$RUNNER_TEMP/release-dist/"*
+      - name: Import the installed wheel outside the checkout
+        run: |
+          uv venv --python 3.12 "$RUNNER_TEMP/release-wheel-env"
+          uv pip install --python "$RUNNER_TEMP/release-wheel-env/bin/python" "$RUNNER_TEMP/release-dist/"*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/release-wheel-env/bin/python" -I -c "import vanilla_option_pricers; print(vanilla_option_pricers.__file__)"
+      - name: Verify artifact metadata and immutable PyPI digests
+        id: artifacts
+        env:
+          RETRY_EXISTING: ${{ inputs.retry_existing || false }}
+        shell: bash
+        run: |
+          args=()
+          if [ "$RETRY_EXISTING" = "true" ]; then args+=(--retry-existing); fi
+          python "$RUNNER_TEMP/release_guard.py" artifacts --tag "$RELEASE_TAG" \
+            --import-name vanilla_option_pricers --dist "$RUNNER_TEMP/release-dist" \
+            --pending "$RUNNER_TEMP/pending-upload" "${args[@]}"
+      - name: Retain verified distributions and their manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: verified-distributions
+          path: ${{ runner.temp }}/release-dist/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Transfer only files approved for this upload
+        if: steps.artifacts.outputs.publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pending-upload
+          path: ${{ runner.temp }}/pending-upload/
+          if-no-files-found: error
+          retention-days: 30
+  publish:
+    needs: validate
+    if: needs.validate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/vanilla-option-pricers/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pending-upload
+          path: dist/
+      - name: Publish verified artifacts through Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: false
+  release-page:
+    needs: [validate, publish]
+    if: always() && inputs.github_release && needs.validate.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Create the optional page only if missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub Release page already exists."
+          else
+            gh release create "$RELEASE_TAG" --verify-tag --generate-notes
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,28 +28,34 @@ it is deliberately not a derivatives framework. Distribution name
 
 ## Ecosystem position
 
-This package is one of eight open-source Python libraries maintained at
-[github.com/ArturSepp](https://github.com/ArturSepp). Before implementing anything
-non-trivial, check whether it already exists in one of these:
+This package is one of ten public Python libraries maintained at
+[github.com/ArturSepp](https://github.com/ArturSepp). Check the owning package before
+adding a capability or copying code between repositories.
 
 | Package | Repository | Purpose |
 |---|---|---|
-| `qis` | QuantInvestStrats | Performance analytics, factsheets, visualisation |
-| `optimalportfolios` | OptimalPortfolios | Portfolio construction and backtesting |
-| `factorlasso` | factorlasso | Sparse factor models and factor covariance estimation |
-| `bbg-fetch` | BloombergFetch | Bloomberg data fetching |
-| `trendfollowing` | TrendFollowingSystems | Trend-following systems: closed-form theory and replication |
-| `goal-based-allocation` | GoalBasedAllocation | Dynamic MV allocation under regime-switching jump-diffusions |
-| `stochvolmodels` | StochVolModels | Stochastic volatility pricing analytics |
-| `vanilla-option-pricers` | VanillaOptionPricers | Vanilla option pricers and implied volatility fitters |
+| `qis` | QuantInvestStrats | performance analytics, backtesting, and factsheet reporting |
+| `optimalportfolios` | OptimalPortfolios | portfolio construction and rolling backtesting |
+| `factorlasso` | FactorLasso | sparse factor-model estimation |
+| `bbg-fetch` | BloombergFetch | Bloomberg data in pandas DataFrames |
+| `stochvolmodels` | StochVolModels | stochastic-volatility pricing and calibration |
+| `trendfollowing` | TrendFollowingSystems | closed-form trend-following analytics |
+| `privateassets` | PrivateAssets | multi-factor PME for private assets |
+| `goal-based-allocation` | GoalBasedAllocation | goal-based allocation under regime-switching jump-diffusions |
+| `vanilla-option-pricers` | VanillaOptionPricers | Numba-vectorised BSM and Bachelier pricing |
+| `option-chain-analytics` | OptionChainAnalytics | point-in-time option-chain data and queries |
 
-Actual package dependencies within the stack: `optimalportfolios` depends on `qis`
-and `factorlasso`; `trendfollowing` depends on `qis`; `stochvolmodels` depends on
-`vanilla-option-pricers` and has an optional `research` extra that pulls in `qis`.
-The others are independent.
+Core dependency edges: `optimalportfolios` consumes `qis` and `factorlasso`;
+`trendfollowing` and `privateassets` consume `qis`; `stochvolmodels` consumes
+`vanilla-option-pricers`; `option-chain-analytics` consumes `qis` and
+`vanilla-option-pricers`. The remaining packages have no core stack dependencies.
 
-Do not vendor or copy code between these packages. If functionality belongs in a
-sibling package, say so rather than reimplementing it here.
+Optional edges: PrivateAssets' `factors` extra adds `factorlasso`; StochVolModels'
+`research` extra adds `qis` and `option-chain-analytics`; OCA's `bloomberg` and `all`
+extras add `bbg-fetch`. Core imports must work without optional dependencies.
+OCA never imports StochVolModels or the private SigmaStrats consumer. Exact
+maintainer-tool exceptions are recorded in `.github/stack-policy.json`; they do
+not authorise adding those dependencies to core or importing them at package root.
 
 ## Repository layout
 
@@ -117,7 +123,7 @@ generated block directly.
 <!-- ===== SHARED AGENT CORE (standalone variant) — begin =====
      Generated from SHARED_AGENT_CORE.md in the maintainer's project knowledge. Do not hand-edit
      between these markers — propose the change to the maintainer instead. Variants: builder
-     (qis) / consumer / standalone. Last synced 2026-08-08, agent core v1.2. -->
+     (qis) / consumer / standalone. Last synced 2026-09-08, agent core v1.5 -->
 
 ## Domain invariants
 
@@ -181,9 +187,11 @@ A release touches three version locations. All three must agree:
 2. `version` and `date-released` in `CITATION.cff`
 3. the software BibTeX entry in `README.md` (if it pins a version)
 
-Then: commit, tag `v<version>`, build and publish to PyPI, and cut a GitHub Release
-with the same tag. Do not bump versions as part of an unrelated change, and do not
-publish without the maintainer explicitly asking for a release.
+For an authorized publication: commit, tag that exact main-reachable commit as
+`v<version>`, then build, verify and publish its artifacts. Frequent PyPI updates are
+supported. A GitHub Release page is optional and created only when requested; it is not
+required for a local build, pip installation or routine package publication. Development
+versions on main may be ahead of PyPI. Do not publish or bump a version for unrelated work.
 
 ## Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,26 @@ Entries start at 1.2.4. For earlier releases see the git log.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-08
+
+### Added
+
+- Added explicit stack dependency and optional-import boundary checks, including
+  isolated maintainer adapters, plus a fresh Python 3.10 lowest-direct dependency CI lane.
+
+- Added tag-driven PyPI Trusted Publishing with release-identity and distribution
+  validation; creating a GitHub Release remains optional.
+
 ### Changed
+
 - Migrated project licence metadata to PEP 639 using the SPDX expression `MIT` and
   declared `LICENSE.txt` as the licence file.
 
+- Aligned package summaries, software citations, README navigation, and documentation
+  landing pages with the canonical package identity and Read the Docs documentation.
+
 ### Removed
+
 - Retired the contributor-facing `dev` extra in favor of PEP 735 `test` and `lint`
   dependency groups; the user-facing `docs` extra remains available.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/ArturSepp/VanillaOptionPricers"
 url: "https://pypi.org/project/vanilla-option-pricers/"
 license: MIT
-version: 2.1.0
-date-released: "2026-08-20"
+version: "2.2.0"
+date-released: "2026-09-08"
 keywords:
   - option-pricing
   - implied-volatility

--- a/README.md
+++ b/README.md
@@ -184,10 +184,6 @@ point-in-time chain workflows and stochastic-volatility models respectively.
   or [`help wanted`](https://github.com/ArturSepp/VanillaOptionPricers/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
   work.
 
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE.txt) file for details.
-
 ## Citation
 
 A machine-readable citation is available in [`CITATION.cff`](CITATION.cff).
@@ -199,8 +195,12 @@ If you use VanillaOptionPricers in your research, please cite it as:
   title={VanillaOptionPricers: Numba-vectorised Black-Scholes-Merton and Bachelier prices, Greeks, and implied-volatility fits over NumPy arrays},
   author={Sepp, Artur},
   year={2026},
-  version={2.1.0},
+  version={2.2.0},
   url={https://github.com/ArturSepp/VanillaOptionPricers},
   note={Python package for forward-based vanilla option pricing and implied-volatility fitting}
 }
 ```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE.txt) file for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ myst:
 
 # vanilla-option-pricers
 
-`vanilla-option-pricers` provides Numba-vectorised Black-Scholes-Merton and Bachelier prices,
-Greeks, and implied-volatility fits over NumPy arrays for quantitative research pipelines.
+Numba-vectorised Black-Scholes-Merton and Bachelier prices, Greeks, and implied-volatility fits
+over NumPy arrays for quantitative research pipelines.
 
 Install the distribution as `vanilla-option-pricers` and import it as
 `vanilla_option_pricers`. The public functions consume caller-supplied forwards, discount

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vanilla-option-pricers"
-version = "2.1.0"
+version = "2.2.0"
 description = "Numba-vectorised Black-Scholes-Merton and Bachelier prices, Greeks, and implied-volatility fits over NumPy arrays for quantitative research pipelines"
 readme = "README.md"
 license = "MIT"
@@ -86,6 +86,11 @@ extend-select = ["TID251", "TID253", "ICN"]
 "privateassets".msg = "A1: subject packages never import each other."
 "stochvolmodels".msg = "A1: subject packages never import each other."
 "goal_based_allocation".msg = "A1: subject packages never import each other."
+"bbg_fetch".msg = "A1: vanilla-option-pricers has no declared dependency on bbg_fetch."
+"factorlasso".msg = "A1: vanilla-option-pricers has no declared dependency on factorlasso."
+"optimalportfolios".msg = "A1: vanilla-option-pricers has no declared dependency on optimalportfolios."
+"option_chain_analytics".msg = "A1: vanilla-option-pricers has no declared dependency on option_chain_analytics."
+"qis".msg = "A1: vanilla-option-pricers has no declared dependency on qis."
 
 [tool.ruff.lint.flake8-tidy-imports]
 banned-module-level-imports = [

--- a/uv.lock
+++ b/uv.lock
@@ -1211,7 +1211,7 @@ wheels = [
 
 [[package]]
 name = "vanilla-option-pricers"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numba" },


### PR DESCRIPTION
Package documentation and public metadata had drifted from the shared registry, and routine PyPI publishing had no common traceability checks.

This change aligns the public surface, adds explicit dependency boundaries and a lowest-dependency CI job, and introduces a tag-based PyPI workflow that builds and verifies artifacts before Trusted Publishing. GitHub Release pages remain optional. Existing numerical implementations and CI matrices are preserved.

Validation: existing documentation builds pass with warnings treated as errors; workflow syntax passes actionlint; focused tooling and package-metadata tests pass. CI checks the complete branch before integration. Published artifact/source provenance gaps remain explicitly recorded rather than retagged without evidence.
